### PR TITLE
Update leaflet-providers_1.9.0.js - Use preferred tile.openstreetmap.…

### DIFF
--- a/docs/articles/flow-table_files/leaflet-providers-1.9.0/leaflet-providers_1.9.0.js
+++ b/docs/articles/flow-table_files/leaflet-providers-1.9.0/leaflet-providers_1.9.0.js
@@ -77,7 +77,7 @@
 
 	L.TileLayer.Provider.providers = {
 		OpenStreetMap: {
-			url: '//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+			url: '//tile.openstreetmap.org/{z}/{x}/{y}.png',
 			options: {
 				maxZoom: 19,
 				attribution:


### PR DESCRIPTION
…org URL

See https://github.com/openstreetmap/operations/issues/737