### PR TITLE
navigate_connected_paths performance and ability to submit pairs (or a data.frame)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,12 +1,16 @@
 Package: hydroloom
 Title: Utilities to Weave Hydrologic Fabrics
 Version: 1.2.0
-Authors@R: 
+Authors@R: c(
     person(given = "David", 
            family = "Blodgett", 
            role = c("aut", "cre"), 
            email = "dblodgett@usgs.gov",
-           comment = c(ORCID = "0000-0001-9489-1710"))
+           comment = c(ORCID = "0000-0001-9489-1710")),
+    person(given = "Andrew",
+           family = "Psoras",
+           role = "ctb",
+           email = "apsoras@usgs.gov"))
 Description: A collection of utilities that support creation of network attributes for hydrologic networks. Methods and algorithms implemented are documented in Moore et al. (2019) <doi:10.3133/ofr20191096>), Cormen and Leiserson (2022) <ISBN:9780262046305> and Verdin and Verdin (1999) <doi:10.1016/S0022-1694(99)00011-6>.  
 Depends: R (>= 4.1.0)
 Imports: dplyr, data.table, sf, units, stats, methods, utils, pbapply, tidyr, RANN, rlang, fastmap

--- a/R/navigate_connected_paths.R
+++ b/R/navigate_connected_paths.R
@@ -9,11 +9,10 @@
 #'
 #' Required attributes: `id`, `toid`, `length_km`
 #' 
-#' If outlets is a vector, all combinations (\link{combn}) of the given outlets will be produced.
-#' If outlets is a list, it must be of length 2 (froms, tos). 
-#' Recycling is performed via \link{expand.grid} if subvector lengths to not match.
-#' outlets may also be a 2-column dataframe to submit pairs.
-#'
+#' If `outlets` is a vector, all combinations (\link{combn}) of the given `outlets` will be produced.
+#' If `outlets` is a list, it must be of length 2 (froms, tos). 
+#' Recycling is performed via \link{expand.grid} if child vector lengths do not match.
+#' `outlets` may also be a 2-column dataframe.
 #'
 #' @returns data.frame containing the distance between pairs of network outlets
 #' and a list column containing flowpath identifiers along path that connect outlets.
@@ -139,7 +138,7 @@ navigate_connected_paths <- function(x, outlets, status = FALSE) {
   df$id_1 <- outlet_ids[match(df$id_1, seq_along(id_match))]
   df$id_2 <- outlet_ids[match(df$id_2, seq_along(id_match))]
 
-  df
+  as.data.frame(df)
 }
 
 #' @title Get Partial Flowpath Length

--- a/R/navigate_connected_paths.R
+++ b/R/navigate_connected_paths.R
@@ -85,12 +85,6 @@ navigate_connected_paths <- function(x, outlets, status = FALSE) {
     }
   }, toindid = index$to)
 
-  # prehashing all_dn since x and y are part of it
-  for (i in seq_along(all_dn)) {
-    fastmatch::fmatch(0, all_dn[[i]])
-  }
-
-
   if (status)
     message("Finding all connected pairs.")    
 
@@ -107,7 +101,7 @@ navigate_connected_paths <- function(x, outlets, status = FALSE) {
       return(x)
     
     if (x[x_len] == y[y_len]) {
-      return(c(x[fastmatch::fmatch(x, y, nomatch = 0) == 0], y[fastmatch::fmatch(y, x, nomatch = 0) == 0]))
+      return(c(x[match(x, y, nomatch = 0) == 0], y[match(y, x, nomatch = 0) == 0]))
     }
     
     numeric(0)

--- a/R/navigate_connected_paths.R
+++ b/R/navigate_connected_paths.R
@@ -134,7 +134,12 @@ navigate_connected_paths <- function(x, outlets, status = FALSE) {
     }
   }, simplify = FALSE)
 
-  rbindlist(paths)
+  df <- rbindlist(paths)
+
+  df$id_1 <- outlet_ids[match(df$id_1, seq_along(id_match))]
+  df$id_2 <- outlet_ids[match(df$id_2, seq_along(id_match))]
+
+  df
 }
 
 #' @title Get Partial Flowpath Length

--- a/R/navigate_connected_paths.R
+++ b/R/navigate_connected_paths.R
@@ -3,11 +3,14 @@
 #' lengths between all identified flowpath outlets. This algorithm finds
 #' paths between outlets regardless of flow direction.
 #' @param x data.frame network compatible with \link{hydroloom_names}.
-#' @param outlets vector of ids from data.frame
+#' @param outlets vector or list of length 2 of ids from data.frame
 #' @param status logical print status and progress bars?
 #' @details
 #'
 #' Required attributes: `id`, `toid`, `length_km`
+#' 
+#' If outlets is a vector, all combinations (\link{combn}) of the given outlets will be produced.
+#' If outlets is a list, it must be of length 2 (froms, tos). Recycling is performed via \link{expand.grid}.
 #'
 #' @returns data.frame containing the distance between pairs of network outlets
 #' and a list column containing flowpath identifiers along path that connect outlets.
@@ -30,9 +33,16 @@ navigate_connected_paths <- function(x, outlets, status = FALSE) {
     on.exit(pboptions(pbopts), add = TRUE)
   }
 
-  stopifnot(is.vector(outlets))
+  # check for list compatibility
+  outlet_ids <- if (is.list(outlets)) {
+    stopifnot(length(outlets) == 2)
+    unique(unlist(outlets))
+  } else {
+    stopifnot(is.vector(outlets))
+    unique(outlets)
+  }
 
-  if (!all(outlets %in% x$id))
+  if (!all(outlet_ids %in% x$id))
     stop("All outlets must be in x.")
 
   x <- st_drop_geometry(x)
@@ -45,16 +55,20 @@ navigate_connected_paths <- function(x, outlets, status = FALSE) {
   if (dim(index$to)[1] != 1) stop("network must be dendritic")
 
   get_dwn <- function(indid, toindid) {
-    next_dn <- toindid[1, indid]
-    if (next_dn == 0) {
-      indid
-    } else {
-      c(indid, get_dwn(next_dn, toindid))
+    next_dn <- toindid[indid]
+    out <- list(indid)
+    i <- 2
+    while (next_dn != 0) {
+      indid <- next_dn
+      next_dn <- toindid[indid]
+      out[[i]] <- indid
+      i <- i + 1
     }
+    unlist(out)
   }
 
-  id_match <- match(outlets, index$to_list$id)
-
+  id_match <- match(outlet_ids, index$to_list$id)
+  
   if (status)
     message("Finding all downstream paths.")
 
@@ -75,63 +89,41 @@ navigate_connected_paths <- function(x, outlets, status = FALSE) {
     y <- all_dn[[p[2]]]
 
     if (length(x) == 1) # if one end is a terminal
-      return(list(x = integer(0), y = y))
+      return(y)
 
     if (length(y) == 1)
-      return(list(x = x, y = integer(0)))
+      return(x)
 
-    if (tail(x, 1) == tail(y, 1))
-      return(list(x = x[!x %in% y], y = y[!y %in% x]))
+    if (x[length(x)] == y[length(y)])
+      return(c(x[!fastmatch::fmatch(x, y, nomatch = 0) > 0], y[!fastmatch::fmatch(y, x, nomatch = 0) > 0]))
 
-    list()
+    numeric(0)
   }
 
-  pairs <- t(combn(length(id_match), 2))
-
-  paths <- pbapply(pairs, 1, get_path, all_dn = all_dn, cl = future_available())
-
-  connected_paths <- paths[lengths(paths) > 0]
-
-  length_km <- select(left_join(index$to_list,
-    select(x, id, "length_km"),
-    by = id),
-  id, "length_km")
-
-  if (status)
-    message("Summing length of all connected pairs.")
-
-  get_length <- function(p, length_km) {
-    sum(length_km$length_km[p[[1]]], length_km$length_km[p[[2]]])
+  # outlet_ids and id_match are interchangeable in combn
+  # since their lengths are equal, but for match
+  # we need outlet_ids to get to an index
+  pairs <- if(is.list(outlets)) {
+    expand.grid(lapply(outlets, \(x) match(x, outlet_ids)))
+  } else {
+    t(combn(length(id_match), 2))
   }
 
-  path_lengths <- pblapply(connected_paths, get_length, length_km = length_km)
+  length_km <- x$length_km
 
-  path_lengths <- cbind(as.data.frame(matrix(id_match[pairs[lengths(paths) > 0, ]],
-    ncol = 2)),
-  data.frame(length = as.numeric(path_lengths)))
+  paths <- pbapply(pairs, 1, \(p) {
+    path <- get_path(p, all_dn)
+    if (length(path) != 0) {
+      list(
+        id_1 = p[1],
+        id_2 = p[2],
+        network_distance_km = sum(length_km[path]),
+        path = list(path)
+      )  
+    }
+  }, simplify = FALSE)
 
-  names(path_lengths) <- c("indid_1", "indid_2", "network_distance_km")
-
-  paths <- cbind(as.data.frame(matrix(id_match[pairs[lengths(paths) > 0, ]],
-    ncol = 2)))
-
-  names(paths) <- c("indid_1", "indid_2")
-
-  paths[["path"]] <- lapply(connected_paths, function(x) {
-    c(x$x, x$y)
-  })
-
-  path_lengths <- left_join(path_lengths, paths, by = c("indid_1", "indid_2"))
-
-  path_lengths <- left_join(path_lengths,
-    select(index$to_list, id_1 = id, indid),
-    by = c("indid_1" = "indid")) |>
-    left_join(select(index$to_list, id_2 = id, indid),
-      by = c("indid_2" = "indid")) |>
-    select(-"indid_1", -"indid_2")
-
-  select(path_lengths, all_of(c("id_1", "id_2", "network_distance_km", "path")))
-
+  rbindlist(paths)
 }
 
 #' @title Get Partial Flowpath Length

--- a/R/navigate_connected_paths.R
+++ b/R/navigate_connected_paths.R
@@ -10,7 +10,10 @@
 #' Required attributes: `id`, `toid`, `length_km`
 #' 
 #' If outlets is a vector, all combinations (\link{combn}) of the given outlets will be produced.
-#' If outlets is a list, it must be of length 2 (froms, tos). Recycling is performed via \link{expand.grid}.
+#' If outlets is a list, it must be of length 2 (froms, tos). 
+#' Recycling is performed via \link{expand.grid} if subvector lengths to not match.
+#' outlets may also be a 2-column dataframe to submit pairs.
+#'
 #'
 #' @returns data.frame containing the distance between pairs of network outlets
 #' and a list column containing flowpath identifiers along path that connect outlets.
@@ -33,7 +36,6 @@ navigate_connected_paths <- function(x, outlets, status = FALSE) {
     on.exit(pboptions(pbopts), add = TRUE)
   }
 
-  # check for list compatibility
   outlet_ids <- if (is.list(outlets)) {
     stopifnot(length(outlets) == 2)
     unique(unlist(outlets))
@@ -72,6 +74,8 @@ navigate_connected_paths <- function(x, outlets, status = FALSE) {
   if (status)
     message("Finding all downstream paths.")
 
+  # we could in theory be storing these as we go and looking up
+  # subsequences but that gets pretty complicated
   all_dn <- pblapply(id_match, function(indid, toindid) {
     out <- get_dwn(indid, toindid)
     if ((lo <- length(out)) > 1) {
@@ -81,30 +85,43 @@ navigate_connected_paths <- function(x, outlets, status = FALSE) {
     }
   }, toindid = index$to)
 
+  # prehashing all_dn since x and y are part of it
+  for (i in seq_along(all_dn)) {
+    fastmatch::fmatch(0, all_dn[[i]])
+  }
+
+
   if (status)
-    message("Finding all connected pairs.")
+    message("Finding all connected pairs.")    
 
   get_path <- function(p, all_dn) {
     x <- all_dn[[p[1]]]
     y <- all_dn[[p[2]]]
+    x_len <- length(x)
+    y_len <- length(y)
 
-    if (length(x) == 1) # if one end is a terminal
+    if (x_len == 1) # if one end is a terminal
       return(y)
-
-    if (length(y) == 1)
+    
+    if (y_len == 1)
       return(x)
-
-    if (x[length(x)] == y[length(y)])
-      return(c(x[!fastmatch::fmatch(x, y, nomatch = 0) > 0], y[!fastmatch::fmatch(y, x, nomatch = 0) > 0]))
-
+    
+    if (x[x_len] == y[y_len]) {
+      return(c(x[fastmatch::fmatch(x, y, nomatch = 0) == 0], y[fastmatch::fmatch(y, x, nomatch = 0) == 0]))
+    }
+    
     numeric(0)
   }
 
   # outlet_ids and id_match are interchangeable in combn
-  # since their lengths are equal, but for match
-  # we need outlet_ids to get to an index
+  # but for outlet list we need to get to an index
   pairs <- if(is.list(outlets)) {
-    expand.grid(lapply(outlets, \(x) match(x, outlet_ids)))
+    if (is.data.frame(outlets) || diff(lengths(outlets)) == 0) {
+      # if the lengths are equal no recycling should be applied
+      sapply(outlets, \(x) match(x, outlet_ids))
+    } else {
+      expand.grid(lapply(outlets, \(x) match(x, outlet_ids)))
+    }
   } else {
     t(combn(length(id_match), 2))
   }

--- a/man/navigate_connected_paths.Rd
+++ b/man/navigate_connected_paths.Rd
@@ -9,7 +9,7 @@ navigate_connected_paths(x, outlets, status = FALSE)
 \arguments{
 \item{x}{data.frame network compatible with \link{hydroloom_names}.}
 
-\item{outlets}{vector of ids from data.frame}
+\item{outlets}{vector or list of length 2 of ids from data.frame}
 
 \item{status}{logical print status and progress bars?}
 }
@@ -25,6 +25,11 @@ paths between outlets regardless of flow direction.
 }
 \details{
 Required attributes: \code{id}, \code{toid}, \code{length_km}
+
+If \code{outlets} is a vector, all combinations (\link{combn}) of the given \code{outlets} will be produced.
+If \code{outlets} is a list, it must be of length 2 (froms, tos).
+Recycling is performed via \link{expand.grid} if child vector lengths do not match.
+\code{outlets} may also be a 2-column dataframe.
 }
 \examples{
 x <- sf::read_sf(system.file("extdata", "walker.gpkg", package = "hydroloom"))

--- a/tests/testthat/test_navigate_connected_paths.R
+++ b/tests/testthat/test_navigate_connected_paths.R
@@ -33,5 +33,43 @@ test_that("navigate connected paths", {
   pbopts <- pbapply::pboptions(type = "none")
   on.exit(pbapply::pboptions(pbopts), add = TRUE)
 
-  expect_equal(length(mess), 3)
+  expect_equal(length(mess), 2)
+})
+
+# List input/output, same case as above
+test_that("navigate_connected_paths", {
+  fline <- sf::read_sf(system.file("extdata", "walker.gpkg", package = "hydroloom"))
+  outlets_vec <- c(5329357, 5329317, 5329365, 5329435, 5329817)
+  fline <- add_toids(fline)
+
+  pl <- navigate_connected_paths(fline, outlets_vec)
+
+  # Checking recycling behavior
+  outlets <- list(
+    outlets_vec[1],
+    outlets_vec[-1]
+  )
+
+  exp_len <- expand.grid(outlets) |> nrow()
+  pl_recycle <- navigate_connected_paths(fline, outlets)
+  expect_equal(nrow(pl_recycle), exp_len)
+  
+  # Checking if we can suppy pairs as-is with no recycling
+  outlets <- list(
+    outlets_vec[1:2],
+    outlets_vec[3:4]
+  )
+
+  pl_asis <- navigate_connected_paths(fline, outlets)
+  expect_equal(nrow(pl_asis), 2)
+
+  # Checking for bad input (also names don't matter)
+  expect_error(navigate_connected_paths(fline, list(1)))
+  expect_error(navigate_connected_paths(fline, list(1, 2, 3)))
+
+  # Checking for correctness with list input
+  expect_equal(pl$network_distance_km[pl$id_1 == 5329357 & pl$id_2 == 5329365],
+    3.6, tolerance = 0.01)
+
+
 })

--- a/tests/testthat/test_navigate_connected_paths.R
+++ b/tests/testthat/test_navigate_connected_paths.R
@@ -68,8 +68,6 @@ test_that("navigate_connected_paths", {
   expect_error(navigate_connected_paths(fline, list(1, 2, 3)))
 
   # Checking for correctness with list input
-  expect_equal(pl$network_distance_km[pl$id_1 == 5329357 & pl$id_2 == 5329365],
+  expect_equal(pl_asis$network_distance_km[pl_asis$id_1 == 5329357 & pl_asis$id_2 == 5329365],
     3.6, tolerance = 0.01)
-
-
 })


### PR DESCRIPTION
Very useful package!
My use case for `navigate_connected_paths` was 45,000 pairs of nhdplus flowlines which I knew to be up/downstream of each other. Because `navigate_connected_paths` does not accept pairs, I had to do this in a loop. The preprocessing of the input `hy` object was at least 50% of the time of execution by my checks in `profvis`, which means the time it took to process at least doubled.

In addition, there were several instances where I ran into recursion errors in `get_dwn`. 

Overall:
- changed `navigate_connected_paths` to accept a list of pairs or 2-col data.frame (executed 1:1), or lopsided list of pairs (executed with expansion) in addition to a vector
- changed `get_dwn` to not use recursion (got `Error: evaluation nested too deeply: infinite recursion / options(expressions=)?
` at times with microbenchmark) - R doesn't optimize recursion in any way so a while loop avoids this risk in big graphs.
- changed `get_dwn` to use lists - avoiding `c()` calls in each iteration was just shy of a 100X speedup, adding to a list avoids memory shuffling associated with resizing vectors/lists.
- changed `get_path` to use `x[length(x)` rather than `tail` - >100X speed up
- cleaned up final code bits where lengths were merged in and summaries were calculated

Overall, the function can do my 45k pair list now in about 8 seconds when before the loop would not complete in <1 h.

The below performance is different to 8 s mentioned above because the length of the paths range widely in my dataset and each one in my set is guaranteed to be a matched pair, but we can approximate it with a vector of outlets that is of length 310, (45150 pairs via `combn` prior to deduplicating)
```
Unit: milliseconds
        expr      min       lq     mean   median       uq      max neval
     current 5085.205 5096.812 5234.333 5214.840 5304.968 5469.838     5
 this_branch  980.914 1071.897 1253.559 1231.648 1263.860 1719.477     5
```

The ability to accept pairs is the main goal as that is added functionality, but ~5X improvement in the base case of `outlets` being a vector doesn't hurt!




